### PR TITLE
Changes to build behind a firewall & add xldDeployLogLevel option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "com.gradle.plugin-publish" version "0.9.7"
+  id "java-gradle-plugin"
   id "com.github.hierynomus.license" version "0.14.0"
   id 'nebula.nebula-release' version '4.0.1'
   id "com.jfrog.bintray" version "1.7.3"
@@ -15,6 +16,15 @@ dependencies {
 
   testCompile group: 'junit', name: 'junit', version: '4.12'
 
+}
+
+gradlePlugin {
+  plugins {
+    xlDeployGradlePlugin {
+      id = "com.xebialabs.xl-deploy"
+      implementationClass = "com.xebialabs.gradle.xldeploy.XlDeployPlugin"
+    }
+  }
 }
 
 release {
@@ -85,6 +95,11 @@ license {
   excludes(["**/*.txt","**/gradlew.*","**/gradle-wrapper.*","src/test/resources/HelloDeployment/.gradle/**"])
 }
 
+clean {
+  delete "src/test/resources/HelloDeployment/.gradle",
+    "src/test/resources/HelloDeployment/build",
+    "src/test/resources/HelloDeployment/userHome"
+}
 
 repositories {
   mavenLocal()
@@ -95,3 +110,15 @@ repositories {
 }
 
 apply from: 'extra_publication.gradle'
+
+// Pass to the external maven repositories after any modifications have been done during
+// the evaluation phase (as in an init.gradle script).  Needed for builds that are done
+// inside a corporate firewall.
+afterEvaluate {
+  String gradleMavenRepos = repositories.withType(MavenArtifactRepository).findAll {
+    it.name != 'MavenLocal' && it.name != 'Embedded Kotlin Repository'
+  }.url.join(',')
+  test {
+    systemProperty 'gradleMavenRepos', gradleMavenRepos
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ license {
   excludes(["**/*.txt","**/gradlew.*","**/gradle-wrapper.*","src/test/resources/HelloDeployment/.gradle/**"])
 }
 
-clean {
+clean.doLast {
   delete "src/test/resources/HelloDeployment/.gradle",
     "src/test/resources/HelloDeployment/build",
     "src/test/resources/HelloDeployment/userHome"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+group=com.xebialabs.gradle

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'xl-deploy-gradle-plugin'

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/BaseDeploymentTask.groovy
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/BaseDeploymentTask.groovy
@@ -15,6 +15,7 @@ import com.xebialabs.deployit.booter.remote.DeployitCommunicator
 import com.xebialabs.deployit.booter.remote.RemoteBooter
 import org.gradle.api.DefaultTask
 import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.logging.LogLevel
 
 import static XlDeployPlugin.PLUGIN_EXTENSION_NAME
 
@@ -60,6 +61,11 @@ abstract class BaseDeploymentTask extends DefaultTask {
    * task will be left as is.
    */
   boolean cancelTaskOnError;
+
+  /**
+   * Set a logging level for deployment messages, defaults to INFO if not set
+   */
+  LogLevel logLevel;
 
   protected DeployitCommunicator communicator;
 

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/DeployTask.groovy
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/DeployTask.groovy
@@ -22,9 +22,8 @@ import com.xebialabs.deployit.plugin.api.udm.ConfigurationItem
 import com.xebialabs.deployit.plugin.api.validation.ValidationMessage
 import org.gradle.api.GradleException
 import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.TaskAction
-
-import static XlDeployPlugin.DEPLOY_TASK_NAME
 
 /**
  * This task uploads a DAR package to XL Deploy and can run a deployment
@@ -39,13 +38,19 @@ class DeployTask extends BaseDeploymentTask {
   @SuppressWarnings("GroovyUnusedDeclaration")
   public void executeDeployment() {
     try {
+      if(xldExtension.xldDeployLogLevel) {
+        logLevel = LogLevel.valueOf(xldExtension.xldDeployLogLevel)
+      }
+      else {
+        logLevel = LogLevel.INFO
+      }
       boot()
       final ConfigurationItem deploymentPackage = uploadPackage();
       environmentId = environmentId ?: xldExtension.xldEnvironmentId
       if (Strings.emptyToNull(environmentId) != null) {
         deployPackage(deploymentPackage)
       } else {
-        logger.info("No environmentId is specified for $DEPLOY_TASK_NAME so skipping deployment")
+        logger.log(logLevel, "No environmentId is specified for $XlDeployPlugin.DEPLOY_TASK_NAME so skipping deployment")
       }
     } finally {
       shutdown()
@@ -64,7 +69,7 @@ class DeployTask extends BaseDeploymentTask {
     def darFile = darFiles.files.getSingleFile()
 
     final ConfigurationItem deploymentPackage = getDeploymentHelper().uploadPackage(darFile);
-    logger.info("Application [${deploymentPackage.getId()}] has been imported");
+    logger.log(logLevel, "Application [${deploymentPackage.getId()}] has been imported");
     return deploymentPackage;
   }
 
@@ -74,20 +79,20 @@ class DeployTask extends BaseDeploymentTask {
     Boolean update = getDeploymentHelper().isApplicationDeployed(deploymentPackage.getId(), targetEnvironment.getId());
     generateDeployment(deploymentPackage, targetEnvironment, update);
 
-    logger.info("Deployeds to be included into generated deployment:");
+    logger.log(logLevel, "Deployeds to be included into generated deployment:");
     for (ConfigurationItem d : generatedDeployment.getDeployeds()) {
-      logger.info("    -> " + d.getId());
+      logger.log(logLevel, "    -> " + d.getId());
     }
 
     if (!Strings.isNullOrEmpty(orchestrator)) {
-      logger.info("Using orchestrator: " + orchestrator);
+      logger.log(logLevel, "Using orchestrator: " + orchestrator);
       generatedDeployment.getDeployedApplication().setProperty("orchestrator", orchestrator);
     }
 
     String taskId = generateDeploymentTask();
     if (testMode) {
-      logger.info(" ... Test mode discovered => displaying and cancelling the generated task");
-      getDeploymentHelper().logTaskState(taskId);
+      logger.log(logLevel, " ... Test mode discovered => displaying and cancelling the generated task");
+      getDeploymentHelper().logTaskState(logLevel, taskId);
       communicator.getProxies().getTaskService().cancel(taskId);
       return;
     }
@@ -105,7 +110,7 @@ class DeployTask extends BaseDeploymentTask {
 
   private ConfigurationItem getTargetEnvironment() {
     if (Strings.emptyToNull(environmentId) == null) {
-      throw new ProjectConfigurationException("Mandatory parameter environmentId is not set for task ${DEPLOY_TASK_NAME}", null);
+      throw new ProjectConfigurationException("Mandatory parameter environmentId is not set for task ${XlDeployPlugin.DEPLOY_TASK_NAME}", null);
     }
 
     ConfigurationItem targetEnvironment = getDeploymentHelper().readCiOrNull(environmentId);
@@ -118,15 +123,19 @@ class DeployTask extends BaseDeploymentTask {
 
   private void runDeploymentTask(String taskId) {
     if (skipMode) {
-      logger.info(" ... Skip mode discovered");
+      logger.log(logLevel, " ... Skip mode discovered");
       getDeploymentHelper().skipAllSteps(taskId);
     }
 
-    logger.lifecycle("Executing generated deployment task: $taskId (run Gradle with '-i' to see detailed output)");
+    String detailedHelpMessage = ""
+    if (logLevel == LogLevel.INFO) {
+      detailedHelpMessage = " (run Gradle with '-i' to see detailed output)"
+    }
+    logger.lifecycle("Executing generated deployment task: $taskId$detailedHelpMessage");
     try {
-      TaskExecutionState taskExecutionState = getDeploymentHelper().executeAndArchiveTask(taskId);
+      TaskExecutionState taskExecutionState = getDeploymentHelper().executeAndArchiveTask(logLevel, taskId);
       if (taskExecutionState.isExecutionHalted()) {
-        throw new GradleException("Errors when executing task $taskId. Please run with '-i' for more information", null);
+        throw new GradleException("Errors when executing task $taskId$detailedHelpMessage", null);
       }
     } catch (IllegalStateException e) {
       if (cancelTaskOnError) {
@@ -139,7 +148,7 @@ class DeployTask extends BaseDeploymentTask {
 
   private String generateDeploymentTask() {
     String taskId;
-    logger.info("Creating a task");
+    logger.log(logLevel, "Creating a task");
     try {
       taskId = communicator.getProxies().getDeploymentService()
           .createTask(getDeploymentHelper().validateDeployment(generatedDeployment));
@@ -149,7 +158,7 @@ class DeployTask extends BaseDeploymentTask {
       }
       throw new RuntimeException(validationError);
     }
-    logger.info("    -> task id: $taskId");
+    logger.log(logLevel, "    -> task id: $taskId");
     return taskId;
   }
 

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/DeployTask.groovy
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/DeployTask.groovy
@@ -38,12 +38,7 @@ class DeployTask extends BaseDeploymentTask {
   @SuppressWarnings("GroovyUnusedDeclaration")
   public void executeDeployment() {
     try {
-      if(xldExtension.xldDeployLogLevel) {
-        logLevel = LogLevel.valueOf(xldExtension.xldDeployLogLevel)
-      }
-      else {
-        logLevel = LogLevel.INFO
-      }
+      logLevel = LogLevel.valueOf(xldExtension.xldDeployLogLevel)
       boot()
       final ConfigurationItem deploymentPackage = uploadPackage();
       environmentId = environmentId ?: xldExtension.xldEnvironmentId

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/DeploymentHelper.java
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/DeploymentHelper.java
@@ -32,6 +32,7 @@ import com.xebialabs.deployit.plugin.api.udm.ConfigurationItem;
 import com.xebialabs.deployit.plugin.api.udm.base.BaseConfigurationItem;
 import com.xebialabs.deployit.plugin.api.validation.ValidationMessage;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 
 import java.io.File;
@@ -84,17 +85,17 @@ public class DeploymentHelper {
      * Starts task, waits until it's done.
      * Returns one of the states: {DONE, EXECUTED, STOPPED, CANCELLED}.
      */
-    public TaskExecutionState executeAndArchiveTask(String taskId) {
+    public TaskExecutionState executeAndArchiveTask(LogLevel logLevel, String taskId) {
         TaskService taskService = proxies.getTaskService();
 
-        log.info("-----------------------");
-        log.info("Task execution plan: ");
-        log.info("-----------------------");
-        logTaskState(taskId);
+        log.log(logLevel, "-----------------------");
+        log.log(logLevel, "Task execution plan: ");
+        log.log(logLevel, "-----------------------");
+        logTaskState(logLevel, taskId);
 
-        log.info("-----------------------");
-        log.info("Task execution progress: ");
-        log.info("-----------------------");
+        log.log(logLevel, "-----------------------");
+        log.log(logLevel, "Task execution progress: ");
+        log.log(logLevel, "-----------------------");
         taskService.start(taskId);
 
         TaskState taskState = taskService.getTask(taskId);
@@ -112,15 +113,15 @@ public class DeploymentHelper {
             taskState = taskService.getTask(taskId);
 
             if (taskState.getCurrentStepNr() > lastLoggedStep) {
-                logStepState(taskId, taskState.getCurrentStepNr());
+                logStepState(logLevel, taskId, taskState.getCurrentStepNr());
                 lastLoggedStep = taskState.getCurrentStepNr();
             }
         }
 
-        log.info("-----------------------");
-        log.info("Task execution result: ");
-        log.info("-----------------------");
-        logTaskState(taskId);
+        log.log(logLevel, "-----------------------");
+        log.log(logLevel, "Task execution result: ");
+        log.log(logLevel, "-----------------------");
+        logTaskState(logLevel, taskId);
 
         taskService.archive(taskId);
 
@@ -131,23 +132,23 @@ public class DeploymentHelper {
     /**
      * Logs information about task and all steps
      */
-    public void logTaskState(String taskId) {
+    public void logTaskState(LogLevel logLevel, String taskId) {
         TaskState taskState = proxies.getTaskService().getTask(taskId);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd hh:mm:ss");
-        log.info(format("%s Description    %s", taskId, taskState.getDescription()));
-        log.info(format("%s State          %s %d/%d", taskId, taskState.getState(), taskState.getCurrentStepNr(), taskState.getNrSteps()));
+        log.log(logLevel, format("%s Description    %s", taskId, taskState.getDescription()));
+        log.log(logLevel, format("%s State          %s %d/%d", taskId, taskState.getState(), taskState.getCurrentStepNr(), taskState.getNrSteps()));
         if (taskState.getStartDate() != null) {
             final GregorianCalendar startDate = taskState.getStartDate().toGregorianCalendar();
-            log.info(format("%s Start      %s", taskId, sdf.format(startDate.getTime())));
+            log.log(logLevel, format("%s Start      %s", taskId, sdf.format(startDate.getTime())));
         }
 
         if (taskState.getCompletionDate() != null) {
             final GregorianCalendar completionDate = taskState.getCompletionDate().toGregorianCalendar();
-            log.info(format("%s Completion %s", taskId, sdf.format(completionDate.getTime())));
+            log.log(logLevel, format("%s Completion %s", taskId, sdf.format(completionDate.getTime())));
         }
 
         for (int i = 1; i <= taskState.getNrSteps(); i++) {
-            logStepState(taskId, i);
+            logStepState(logLevel, taskId, i);
         }
 
         if (TaskExecutionState.STOPPED.equals(taskState.getState()))
@@ -157,7 +158,7 @@ public class DeploymentHelper {
     /**
      * Logs information about single step
      */
-    public void logStepState(String taskId, int stepNumber) {
+    public void logStepState(LogLevel logLevel, String taskId, int stepNumber) {
         final StepState stepInfo = proxies.getTaskService().getStep(taskId, stepNumber, null);
         final String description = stepInfo.getDescription();
         String stepInfoMessage;
@@ -167,7 +168,7 @@ public class DeploymentHelper {
             stepInfoMessage = format("%s step #%d %s\t%s\n%s", taskId, stepNumber, stepInfo.getState(), description, stepInfo.getLog());
         }
 
-        log.info(stepInfoMessage);
+        log.log(logLevel, stepInfoMessage);
 
     }
 

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/XlDeployPluginExtension.groovy
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/XlDeployPluginExtension.groovy
@@ -41,4 +41,8 @@ class XlDeployPluginExtension {
    */
   String xldEnvironmentId
 
+  /**
+   * LogLevel to use for deployment messages, defaults to INFO
+   */
+  String xldDeployLogLevel
 }

--- a/src/main/groovy/com/xebialabs/gradle/xldeploy/XlDeployPluginExtension.groovy
+++ b/src/main/groovy/com/xebialabs/gradle/xldeploy/XlDeployPluginExtension.groovy
@@ -11,6 +11,7 @@
 package com.xebialabs.gradle.xldeploy
 
 import org.gradle.api.Project
+import org.gradle.api.logging.LogLevel
 
 class XlDeployPluginExtension {
   Project project
@@ -44,5 +45,5 @@ class XlDeployPluginExtension {
   /**
    * LogLevel to use for deployment messages, defaults to INFO
    */
-  String xldDeployLogLevel
+  String xldDeployLogLevel = LogLevel.INFO
 }

--- a/src/test/groovy/com/xebialabs/gradle/xldeploy/DarConfigurationTaskTest.groovy
+++ b/src/test/groovy/com/xebialabs/gradle/xldeploy/DarConfigurationTaskTest.groovy
@@ -13,6 +13,7 @@ package com.xebialabs.gradle.xldeploy
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.bundling.War
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
@@ -158,5 +159,12 @@ class DarConfigurationTaskTest {
     generatedManifest.write("""<udm.DeploymentPackage version="\${project.version}" application="HelloDeployment"/>""")
     configureDar.execute()
     assert configureDar.evaluatedManifest.resolvedManifestContent.contains("version=\"1.0\"")
+  }
+
+  @Test
+  public void defaultLogLevelIsInfo() {
+    def ext = project.extensions.getByName(XlDeployPlugin.PLUGIN_EXTENSION_NAME) as XlDeployPluginExtension
+    def logLevel = LogLevel.valueOf(ext.xldDeployLogLevel)
+    assert logLevel == LogLevel.INFO
   }
 }

--- a/src/test/groovy/com/xebialabs/gradle/xldeploy/DarConfigurationTaskTest.groovy
+++ b/src/test/groovy/com/xebialabs/gradle/xldeploy/DarConfigurationTaskTest.groovy
@@ -36,8 +36,17 @@ class DarConfigurationTaskTest {
     project.apply plugin: 'war'
     project.apply plugin: XlDeployPlugin
     project.version = "1.0"
+    // Support for Gradle test runner passing in parent builds repositories to support builds behind a corporate firewall.
+    List<String> gradleMavenRepos = System.getProperty('gradleMavenRepos', '').split(/,/)
     project.dependencies {
-      project.getRepositories().mavenCentral()
+      if(gradleMavenRepos) {
+        gradleMavenRepos.each { repo ->
+          project.getRepositories().maven { url = repo }
+        }
+      }
+      else {
+        project.getRepositories().mavenCentral()
+      }
     }
 
     configureDar = project.tasks.configureDar as DarConfigurationTask


### PR DESCRIPTION
In our environment we must build behind a corporate firewall.  We have made changes to the build files and tests so that behind a firewall (if you use an init.gradle that remaps repositories from external to internal mirrors) that this project will build.  Also we have added the configuration so that we can publish the plugin to an internal Maven repo (if you use an init.gradle that adds internal publishing configuration).  Finally we have added to the clean step so that it cleans the Test work area of Gradle test artifacts.  If you are not behind a firewall it will continue to build as before.  

Also we have had a need to do the full logging at the LogLevel.LIFECYCLE.  I've added an optional configuration so that the detailed deployment log level can be set but the plugin user with a new xldDeployLogLevel configuration option that defaults to the old behavior of LogLevel.INFO.